### PR TITLE
Fix typo in challenges page hero section title

### DIFF
--- a/src/components/challenges/ChallengesList.js
+++ b/src/components/challenges/ChallengesList.js
@@ -12,7 +12,7 @@ const ChallengesList = () => {
   return (
     <main className="sm:ml-0 px-5 row-start-2 row-end-3 col-start-2 col-end-3">
       <Hero
-        title="Here are some handcrafted challenges for you. Keep Cooding! 👨‍💻"
+        title="Here are some handcrafted challenges for you. Keep Coding! 👨‍💻"
         subTitle="Today is a great day to start a new challenge 🧑‍💻"
         mainImg={challengeLottie}
         btnTitle="Explore Challenges "


### PR DESCRIPTION
**Describe the bug**
Coding is spelled Cooding in challenges page hero section title

**Screenshot**

<img width="946" alt="typo" src="https://user-images.githubusercontent.com/49714931/134722948-07a82a67-6de4-46ce-b264-269c4b880f0b.png">