### PR TITLE
fix: discord button size on mobile and tablet

### DIFF
--- a/src/components/layouts/SideBar.js
+++ b/src/components/layouts/SideBar.js
@@ -75,7 +75,7 @@ const Sidebar = () => {
               href="https://discord.com/invite/FYSQUEw6xP"
               target="_blank"
               rel="noopener noreferrer"
-              className="bg-blue-500 flex items-center justify-center p-3 xl:px-6 rounded transition-all duration-200 bg-gradient-to-br hover:from-purple-500 hover:to-indigo-500 hover:text-white text-base xs:text-left md:text-center lg:text-left"
+              className="bg-blue-500 flex items-center justify-center p-3 rounded transition-all duration-200 bg-gradient-to-br hover:from-purple-500 hover:to-indigo-500 hover:text-white text-base w-full xl:mx-3"
             >
               <i className="fab fa-discord text-2xl mr-1 xs:mr-3 md:mr-0 xl:mr-3 xl:text-base text-center"></i>
               <span className="xs:inline-block md:hidden xl:inline-block">Join Discord</span>


### PR DESCRIPTION
fixed the size of the button on mobile and tablet.
- The button now takes full width on mobile
- The tablet button is now square instead of the previous rectangl

mobile:
![mobile](https://user-images.githubusercontent.com/65021509/134892999-fdda844d-bc18-4076-9738-134c7d7630e7.JPG)

Tablet:
![tablet](https://user-images.githubusercontent.com/65021509/134893013-cd1fa443-460e-4e85-944f-b8de7e1a7099.JPG)