### PR TITLE
Added click listener to the logo 

### DIFF
--- a/src/components/layouts/NavItem.js
+++ b/src/components/layouts/NavItem.js
@@ -1,13 +1,14 @@
 import React from "react"
 import { NavLink } from "react-router-dom"
 
-const NavItem = ({ item, icon }) => {
+const NavItem = ({ item, icon, setIsOpen }) => {
   return (
     <NavLink
       className="block p-3 mb-3 rounded transition-all  duration-200 bg-gradient-to-br hover:from-purple-500 hover:to-indigo-500 hover:text-white text-base xs:text-left md:text-center xl:text-left relative"
       to={`/${item}`}
       aria-label={item}
       title={`This is a link to ${item}`}
+      onClick={() => setIsOpen(false)}
     >
       <i
         className={`xs:mr-3 md:mr-0 xl:mr-3 ${icon} text-xl xl:text-base text-center`}

--- a/src/components/layouts/SideBar.js
+++ b/src/components/layouts/SideBar.js
@@ -63,10 +63,14 @@ const Sidebar = () => {
 
           {/* <!-- nav --> */}
           <aside className="xs:pt-4 md:pt-8 bg-gray-900">
-            <NavItem item="challenges" icon="fas fa-code" />
-            <NavItem item="solutions" icon="fas fa-laptop-code" />
-            <NavItem item="resources" icon="fas fa-chalkboard-teacher " />
-            <NavItem item="roadmaps" icon="fas fa-map-signs" />
+            <NavItem item="challenges" icon="fas fa-code" setIsOpen={setIsOpen} />
+            <NavItem item="solutions" icon="fas fa-laptop-code" setIsOpen={setIsOpen} />
+            <NavItem
+              item="resources"
+              icon="fas fa-chalkboard-teacher "
+              setIsOpen={setIsOpen}
+            />
+            <NavItem item="roadmaps" icon="fas fa-map-signs" setIsOpen={setIsOpen} />
           </aside>
 
           {/* <!-- discord buton --> */}
@@ -78,7 +82,9 @@ const Sidebar = () => {
               className="bg-blue-500 flex items-center justify-center p-3 rounded transition-all duration-200 bg-gradient-to-br hover:from-purple-500 hover:to-indigo-500 hover:text-white text-base w-full xl:mx-3"
             >
               <i className="fab fa-discord text-2xl mr-1 xs:mr-3 md:mr-0 xl:mr-3 xl:text-base text-center"></i>
-              <span className="xs:inline-block md:hidden xl:inline-block">Join Discord</span>
+              <span className="xs:inline-block md:hidden xl:inline-block">
+                Join Discord
+              </span>
             </a>
           </div>
         </div>

--- a/src/components/layouts/SideBar.js
+++ b/src/components/layouts/SideBar.js
@@ -45,6 +45,7 @@ const Sidebar = () => {
               className="text-white flex items-center space-x-2 font-heading uppercase text-center px-4 font-semibold text-xl"
               aria-label="codingspace logo"
               title="This is a link to codingspace homepage"
+              onClick={() => setIsOpen(false)}
             >
               <i className="fas fa-rocket mr-1"></i>
               <span className="xs:inline-block md:hidden xl:inline-block">


### PR DESCRIPTION
fixes: #66 
# Description: 
Initially there was not closing functionality in the logo. 
Added Click Listener to close the sidebar on clicking the logo.
