### PR TITLE
Fix crash when currentUser has no displayName

### DIFF
--- a/src/components/challenges/ChallengeHeader.js
+++ b/src/components/challenges/ChallengeHeader.js
@@ -11,7 +11,11 @@ import Button from "../smallComponents/Button"
 
 const ChallengeHeader = ({ docs, button }) => {
   const { currentUser } = useAuth()
-  const displayName = currentUser ? currentUser.displayName.split(" ")[0] : "Coder"
+  const displayName = currentUser
+    ? currentUser.displayName !== null
+      ? currentUser.displayName.split(" ")[0]
+      : "Coder"
+    : "Coder"
   const history = useHistory()
   const solutionDetails = docs.map(({ id, ...r }) => {
     r.challengeID = id


### PR DESCRIPTION
I was browsing the live website but could not access any challenges after being logged in with Github.
After a quick check, there is a bug in `ChallengeHeader` when `currentUser.displayName` doesn't exist.

For the solution, I took the same code I found in `src/components/dashboard/Hero.js`:
https://github.com/rishipurwar1/coding-space/blob/ece238f583cafaed92f5bf8c48debe849bf9d71f/src/components/dashboard/Hero.js#L12-L16