### PR TITLE
Added link to card text - little UX improvement

### DIFF
--- a/src/components/challenges/ChallengeCard.js
+++ b/src/components/challenges/ChallengeCard.js
@@ -26,7 +26,9 @@ const ChallengeCard = ({ challenge, challengelist, btnTitle }) => {
       </div>
       <div className="flex-1 mb-4 card-content">
         <h3 className="font-semibold font-heading text-2xl text-white px-4 leading-6">
-          {challenge.title}
+          <a href={link} style={{ textDecoration: "none"}}>
+            {challenge.title}
+          </a>
         </h3>
         <p className="text-base text-gray-400 px-4 py-4">{challenge.description}</p>
       </div>


### PR DESCRIPTION
Problem:
Cards and fonts are quite big and because of which the link to the challenge is not visible to the user on the first scroll and only text and image are visible which makes it look like an unclickable card at first glance.

Changes:
Added link to Title so that user can go to challenge easily

Suggestion:
We could make an entire card a clickable element as well to reduce work from the user side