### PR TITLE
feat: add pagination in solutions page

### DIFF
--- a/src/components/SvgIcons/Icons.js
+++ b/src/components/SvgIcons/Icons.js
@@ -611,6 +611,44 @@ const Icons = {
       <path d="M19 11h-4a1 1 0 0 1 -1 -1v-3a1 1 0 0 1 1 -1h3a1 1 0 0 1 1 1v6c0 2.667 -1.333 4.333 -4 5"></path>
     </svg>
   ),
+  ArrowLeft: ({ size = 24, ...props }) => (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+      <path d="M5 12l14 0" />
+      <path d="M5 12l4 4" />
+      <path d="M5 12l4 -4" />
+    </svg>
+  ),
+  ArrowRight: ({ size = 24, ...props }) => (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+      <path d="M5 12l14 0" />
+      <path d="M15 16l4 -4" />
+      <path d="M15 8l4 4" />
+    </svg>
+  ),
 }
 
 export default Icons

--- a/src/firebase/firestore.js
+++ b/src/firebase/firestore.js
@@ -13,11 +13,21 @@ import { postToJSON } from "../utils/shared"
 
 import { db } from "./config"
 
-export const getDocuments = async (c, q = null, l) => {
+// Generic helper to fetch documents from a collection, ordered by "createdAt" (newest first).
+// - c: collection name
+// - q: optional Firestore "where" tuple, e.g. ["completed", "==", true]
+// - l: optional numeric limit
+export const getDocuments = async (c, q = null, l = null) => {
   const queryConstraints = []
 
-  if (q !== null) queryConstraints.push(where(...q))
-  if (l !== null) queryConstraints.push(limit(l))
+  if (q !== null) {
+    queryConstraints.push(where(...q))
+  }
+
+  // Only apply limit when a valid number is provided.
+  if (typeof l === "number") {
+    queryConstraints.push(limit(l))
+  }
 
   const ref = collection(db, c)
   const docsRef = query(ref, orderBy("createdAt", "desc"), ...queryConstraints)


### PR DESCRIPTION
This PR introduces **server-side pagination** for fetching `solutions` from Firebase to prevent loading all documents at once.

Previously, all completed solutions were fetched in a single request during `getServerSideProps`, which did not scale well as the number of documents grew. This update adds page-based pagination using a fixed `PAGE_SIZE`, driven by the `page` query parameter.

### What changed
- Added page-based pagination logic in `getServerSideProps`
- Fetches only the required number of documents per page
- Determines `hasNextPage` by fetching one extra document
- Returns pagination metadata (`currentPage`, `hasNextPage`, `hasPrevPage`) to the client

### Benefits
- Reduces unnecessary Firebase reads
- Improves server response time and initial page load
- Scales better as the number of documents grows
